### PR TITLE
Upgrading Travis back to SDK-25

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,20 +10,20 @@ android:
     - tools
     - platform-tools
     - tools
-    - build-tools-22.0.1
-    - android-22
+    - build-tools-25.0.0
+    - android-25
     - extra-android-m2repository
     - extra-google-m2repository
     - extra-android-support
     - extra-google-google_play_services
-    - sys-img-armeabi-v7a-android-22
+    - sys-img-armeabi-v7a-android-25
 env:
   global:
     - ADB_INSTALL_TIMEOUT=8
 
 before_script:
-  - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a
-  - emulator -avd test -no-audio -no-window &
+  - echo no | android create avd --force -n test -t android-25 --abi armeabi-v7a
+  - emulator -avd test -no-skin -no-audio -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,13 @@ android:
     - extra-google-m2repository
     - extra-android-support
     - extra-google-google_play_services
-    - sys-img-armeabi-v7a-android-25
+    - sys-img-armeabi-v7a-android-22
 env:
   global:
     - ADB_INSTALL_TIMEOUT=8
 
 before_script:
-  - echo no | android create avd --force -n test -t android-25 --abi armeabi-v7a
+  - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a
   - emulator -avd test -no-skin -no-audio -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82 &

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ android:
     - platform-tools
     - tools
     - build-tools-25.0.0
+    - android-22
     - android-25
     - extra-android-m2repository
     - extra-google-m2repository


### PR DESCRIPTION
The project is using 25, so I should use that in Travis too. I’m
checking if I can install and run the Android 25 emulator.